### PR TITLE
Fix message return in nil to error

### DIFF
--- a/lib/crudry_resolver.ex
+++ b/lib/crudry_resolver.ex
@@ -40,12 +40,12 @@ defmodule Crudry.Resolver do
 
         def update_my_schema(%{id: id, params: params}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error("my_schema", fn record -> MyContext.update_my_schema(record, params) end)
+          |> nil_to_error("My Schema", fn record -> MyContext.update_my_schema(record, params) end)
         end
 
         def delete_my_schema(%{id: id}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error("my_schema", fn record -> MyContext.delete_my_schema(record) end)
+          |> nil_to_error("My Schema", fn record -> MyContext.delete_my_schema(record) end)
         end
 
         # If `result` is `nil`, return an error. Otherwise, apply `func` to the `result`.
@@ -69,7 +69,7 @@ defmodule Crudry.Resolver do
 
         def update_my_schema(%{id: id, params: params}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error("my_schema", fn record -> MyContext.update_my_schema_with_assocs(record, params, [:assoc]) end)
+          |> nil_to_error("My Schema", fn record -> MyContext.update_my_schema_with_assocs(record, params, [:assoc]) end)
         end
       end
 

--- a/lib/crudry_resolver.ex
+++ b/lib/crudry_resolver.ex
@@ -34,11 +34,11 @@ defmodule Crudry.Resolver do
           MyContext.list_my_schemas()
         end
 
-        def create_my_schema(%{my_schema: params}, _info) do
+        def create_my_schema(%{params: params}, _info) do
           MyContext.create_my_schema(params)
         end
 
-        def update_my_schema(%{id: id, my_schema: params}, _info) do
+        def update_my_schema(%{id: id, params: params}, _info) do
           MyContext.get_my_schema(id)
           |> nil_to_error("my_schema", fn record -> MyContext.update_my_schema(record, params) end)
         end
@@ -67,7 +67,7 @@ defmodule Crudry.Resolver do
 
         Crudry.Resolver.generate_functions MyContext, MySchema, except: [:update]
 
-        def update_my_schema(%{id: id, my_schema: params}, _info) do
+        def update_my_schema(%{id: id, params: params}, _info) do
           MyContext.get_my_schema(id)
           |> nil_to_error("my_schema", fn record -> MyContext.update_my_schema_with_assocs(record, params, [:assoc]) end)
         end

--- a/lib/crudry_resolver.ex
+++ b/lib/crudry_resolver.ex
@@ -27,29 +27,29 @@ defmodule Crudry.Resolver do
 
         def get_my_schema(%{id: id}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error(fn record -> {:ok, record} end)
+          |> nil_to_error("my_schema", fn record -> {:ok, record} end)
         end
 
         def list_my_schemas(_args, _info) do
           MyContext.list_my_schemas()
         end
 
-        def create_my_schema(%{params: params}, _info) do
+        def create_my_schema(%{my_schema: params}, _info) do
           MyContext.create_my_schema(params)
         end
 
-        def update_my_schema(%{id: id, params: params}, _info) do
+        def update_my_schema(%{id: id, my_schema: params}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error(fn record -> MyContext.update_my_schema(record, params) end)
+          |> nil_to_error("my_schema", fn record -> MyContext.update_my_schema(record, params) end)
         end
 
         def delete_my_schema(%{id: id}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error(fn record -> MyContext.delete_my_schema(record) end)
+          |> nil_to_error("my_schema", fn record -> MyContext.delete_my_schema(record) end)
         end
 
         # If `result` is `nil`, return an error. Otherwise, apply `func` to the `result`.
-        def nil_to_error(result, func) do
+        def nil_to_error(result, "my_schema", func) do
           case result do
             nil -> {:error, "MySchema not found."}
             %{} = record -> func.(record)
@@ -67,9 +67,9 @@ defmodule Crudry.Resolver do
 
         Crudry.Resolver.generate_functions MyContext, MySchema, except: [:update]
 
-        def update_my_schema(%{id: id, params: params}, _info) do
+        def update_my_schema(%{id: id, my_schema: params}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error(fn record -> MyContext.update_my_schema_with_assocs(record, params, [:assoc]) end)
+          |> nil_to_error("my_schema", fn record -> MyContext.update_my_schema_with_assocs(record, params, [:assoc]) end)
         end
       end
 
@@ -125,7 +125,7 @@ defmodule Crudry.Resolver do
       AccountsResolver.crete_user(%{params: params}, info)
       AccountsResolver.update_user(%{id: id, params: params}, info)
       AccountsResolver.delete_user(%{id: id}, info)
-      AccountsResolver.nil_to_error(result, func)
+      AccountsResolver.nil_to_error(result, "my_schema", func)
   """
   defmacro generate_functions(context, schema_module, opts \\ []) do
     opts = Keyword.merge(load_default(__CALLER__.module), opts)

--- a/lib/crudry_resolver.ex
+++ b/lib/crudry_resolver.ex
@@ -27,7 +27,7 @@ defmodule Crudry.Resolver do
 
         def get_my_schema(%{id: id}, _info) do
           MyContext.get_my_schema(id)
-          |> nil_to_error("my_schema", fn record -> {:ok, record} end)
+          |> nil_to_error("My Schema", fn record -> {:ok, record} end)
         end
 
         def list_my_schemas(_args, _info) do
@@ -49,9 +49,9 @@ defmodule Crudry.Resolver do
         end
 
         # If `result` is `nil`, return an error. Otherwise, apply `func` to the `result`.
-        def nil_to_error(result, "my_schema", func) do
+        def nil_to_error(result, name, func) do
           case result do
-            nil -> {:error, "MySchema not found."}
+            nil -> {:error, "\#{name} not found."}
             %{} = record -> func.(record)
           end
         end
@@ -125,7 +125,7 @@ defmodule Crudry.Resolver do
       AccountsResolver.crete_user(%{params: params}, info)
       AccountsResolver.update_user(%{id: id, params: params}, info)
       AccountsResolver.delete_user(%{id: id}, info)
-      AccountsResolver.nil_to_error(result, "my_schema", func)
+      AccountsResolver.nil_to_error(result, name, func)
   """
   defmacro generate_functions(context, schema_module, opts \\ []) do
     opts = Keyword.merge(load_default(__CALLER__.module), opts)

--- a/lib/resolver_functions_generator.ex
+++ b/lib/resolver_functions_generator.ex
@@ -50,7 +50,7 @@ defmodule ResolverFunctionsGenerator do
     quote do
       def unquote(:nil_to_error)(result, name, func) do
         case result do
-          nil -> {:error, "#{Macro.camelize(name)} not found."}
+          nil -> {:error, "#{name} not found."}
           %{} = record -> func.(record)
         end
       end

--- a/lib/resolver_functions_generator.ex
+++ b/lib/resolver_functions_generator.ex
@@ -5,7 +5,7 @@ defmodule ResolverFunctionsGenerator do
     quote do
       def unquote(:"get_#{name}")(%{id: id}, _info) do
         apply(unquote(context), String.to_existing_atom("get_#{unquote(name)}"), [id])
-        |> nil_to_error(fn record -> {:ok, record} end)
+        |> nil_to_error(unquote(name), fn record -> {:ok, record} end)
       end
     end
   end
@@ -32,7 +32,7 @@ defmodule ResolverFunctionsGenerator do
     quote do
       def unquote(:"update_#{name}")(%{id: id, params: params}, _info) do
         apply(unquote(context), String.to_existing_atom("get_#{unquote(name)}"), [id])
-        |> nil_to_error(fn record -> apply(unquote(context), String.to_existing_atom("update_#{unquote(name)}"), [record, params]) end)
+        |> nil_to_error(unquote(name), fn record -> apply(unquote(context), String.to_existing_atom("update_#{unquote(name)}"), [record, params]) end)
       end
     end
   end
@@ -41,16 +41,16 @@ defmodule ResolverFunctionsGenerator do
     quote do
       def unquote(:"delete_#{name}")(%{id: id}, _info) do
         apply(unquote(context), String.to_existing_atom("get_#{unquote(name)}"), [id])
-        |> nil_to_error(fn record -> apply(unquote(context), String.to_existing_atom("delete_#{unquote(name)}"), [record]) end)
+        |> nil_to_error(unquote(name), fn record -> apply(unquote(context), String.to_existing_atom("delete_#{unquote(name)}"), [record]) end)
       end
     end
   end
 
-  def generate_function(:nil_to_error, name, _context) do
+  def generate_function(:nil_to_error, _name, _context) do
     quote do
-      def unquote(:nil_to_error)(result, func) do
+      def unquote(:nil_to_error)(result, name, func) do
         case result do
-          nil -> {:error, "#{Macro.camelize(unquote(name))} not found."}
+          nil -> {:error, "#{Macro.camelize(name)} not found."}
           %{} = record -> func.(record)
         end
       end

--- a/lib/resolver_functions_generator.ex
+++ b/lib/resolver_functions_generator.ex
@@ -50,7 +50,7 @@ defmodule ResolverFunctionsGenerator do
     quote do
       def unquote(:nil_to_error)(result, name, func) do
         case result do
-          nil -> {:error, "#{name} not found."}
+          nil -> {:error, "#{Macro.camelize(name)} not found."}
           %{} = record -> func.(record)
         end
       end

--- a/test/crudry_resolver_test.exs
+++ b/test/crudry_resolver_test.exs
@@ -82,7 +82,7 @@ defmodule CrudryResolverTest do
 
       def update_test(%{id: id, params: params}, _info) do
         Context.get_test(id)
-        |> nil_to_error(fn record -> Context.update_test_with_assocs(record, params, [:assoc]) end)
+        |> nil_to_error("test", fn record -> Context.update_test_with_assocs(record, params, [:assoc]) end)
       end
     end
 


### PR DESCRIPTION
Fix an error when nil_to_error is returning e.g: "**User** not found." when doing delete/get/update a Post who does not exist while it should return "**Post** not found".