### PR TITLE
Optimize search to ignore on empty string

### DIFF
--- a/lib/crudry_query.ex
+++ b/lib/crudry_query.ex
@@ -73,6 +73,10 @@ defmodule Crudry.Query do
     initial_query
   end
 
+  def search(initial_query, "", _fields) do
+    initial_query
+  end
+
   def search(initial_query, search_term, fields) do
     Enum.reduce(fields, subquery(initial_query), fn
       module_field, query_acc ->

--- a/priv/repo/migrations/20190116115123_create_tables.exs
+++ b/priv/repo/migrations/20190116115123_create_tables.exs
@@ -12,6 +12,7 @@ defmodule Crudry.Repo.Migrations.CreateTables do
       add :username, :string
       add :age, :integer
       add :password, :string
+      add :bio, :string
       add :company_id, references(:companies)
 
       timestamps()

--- a/test/crudry_query_test.exs
+++ b/test/crudry_query_test.exs
@@ -3,8 +3,8 @@ defmodule CrudryQueryTest do
 
   alias Crudry.{Repo, User}
 
-  @user %{username: "Chuck Norris", age: 60}
-  @user2 %{username: "Will Smith", age: 60}
+  @user %{username: "Chuck Norris", age: 60, bio: "user bio"}
+  @user2 %{username: "Will Smith", age: 60, bio: nil}
   @user3 %{username: "Aa", age: 40}
   @user4 %{username: "Zz", age: 66}
   @user5 %{username: "Crudry", age: 3}
@@ -37,7 +37,7 @@ defmodule CrudryQueryTest do
 
     test "ignores search term when it is nil" do
       initial_query = User
-      query = Crudry.Query.search(initial_query, nil, [:username])
+      query = Crudry.Query.search(initial_query, nil, [:bio])
 
       users = Repo.all(query)
 
@@ -47,7 +47,7 @@ defmodule CrudryQueryTest do
 
     test "ignores search term when it is empty string" do
       initial_query = User
-      query = Crudry.Query.search(initial_query, "", [:username])
+      query = Crudry.Query.search(initial_query, "", [:bio])
 
       users = Repo.all(query)
 

--- a/test/crudry_query_test.exs
+++ b/test/crudry_query_test.exs
@@ -32,16 +32,27 @@ defmodule CrudryQueryTest do
 
       # Since we first filtered out all users that don't have @user.username,
       # the search for @user2.username shouldn't find anything
-      assert length(users) == 0
+      assert 0 == length(users)
     end
 
     test "ignores search term when it is nil" do
-      users =
-        User
-        |> Crudry.Query.search(nil, [:username])
-        |> Repo.all()
+      initial_query = User
+      query = Crudry.Query.search(initial_query, nil, [:username])
 
-      assert length(users) == 2
+      users = Repo.all(query)
+
+      assert initial_query == query
+      assert 2 == length(users)
+    end
+
+    test "ignores search term when it is empty string" do
+      initial_query = User
+      query = Crudry.Query.search(initial_query, "", [:username])
+
+      users = Repo.all(query)
+
+      assert initial_query == query
+      assert 2 == length(users)
     end
   end
 

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -6,6 +6,7 @@ defmodule Crudry.User do
     field(:username, :string)
     field(:age, :integer)
     field(:password, :string)
+    field(:bio, :string)
 
     belongs_to(:company, Crudry.Company)
     has_many(:posts, Crudry.Post)
@@ -35,7 +36,7 @@ defmodule Crudry.User do
 
   defp base_changeset(user, attrs) do
     user
-    |> cast(attrs, [:username, :age, :password, :company_id])
+    |> cast(attrs, [:username, :age, :password, :bio, :company_id])
     |> validate_required([:username])
     |> validate_length(:username, min: 2)
     |> validate_number(:age, greater_than: 0)


### PR DESCRIPTION
This PR intends to optimize a little the query generated when using `Crudry.Query.search/3`.

But this is possibly a breaking change, since before this change, with an empty `search_term`, the rows that have null values for any of the columns specified in `fields` were being filtered out. With this PR, the rows with null values will be returned too.

What do you guys think, should we proceed with this change?