### PR TITLE
Adding preload to get_schema to remove with_assoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ def middleware(middleware, _field, _object) do
 end
 ```
 
-`Cudry.Translator` is used by default to translate error messages to the default locale `en`. You can also use your own Gettext module by adding it to your Absinthe's schema `context/1` function:
+`Crudry.Translator` is used by default to translate error messages to the default locale `en`. You can also use your own Gettext module by adding it to your Absinthe's schema `context/1` function:
 
 ```elixir
 def context(context) do

--- a/lib/context_functions_generator.ex
+++ b/lib/context_functions_generator.ex
@@ -13,13 +13,19 @@ defmodule ContextFunctionsGenerator do
   def generate_function(:get, name, _pluralized_name, module, opts) do
     quote do
       def unquote(:"get_#{name}")(id, repo_opts \\ []) do
+        assocs = repo_opts[:assocs] || []
+
         unquote(module)
         |> unquote(get_repo_module(opts)).get(id, repo_opts)
+        |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
       def unquote(:"get_#{name}_by")(clauses, repo_opts \\ []) do
+        assocs = repo_opts[:assocs] || []
+
         unquote(module)
         |> unquote(get_repo_module(opts)).get_by(clauses, repo_opts)
+        |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
       def unquote(:"get_#{name}_with_assocs")(id, assocs, repo_opts \\ []) do
@@ -35,13 +41,19 @@ defmodule ContextFunctionsGenerator do
       end
 
       def unquote(:"get_#{name}!")(id, repo_opts \\ []) do
+        assocs = repo_opts[:assocs] || []
+
         unquote(module)
         |> unquote(get_repo_module(opts)).get!(id, repo_opts)
+        |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
       def unquote(:"get_#{name}_by!")(clauses, repo_opts \\ []) do
+        assocs = repo_opts[:assocs] || []
+
         unquote(module)
         |> unquote(get_repo_module(opts)).get_by!(clauses, repo_opts)
+        |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
       def unquote(:"get_#{name}_with_assocs!")(id, assocs, repo_opts \\ []) do

--- a/lib/context_functions_generator.ex
+++ b/lib/context_functions_generator.ex
@@ -12,56 +12,60 @@ defmodule ContextFunctionsGenerator do
 
   def generate_function(:get, name, _pluralized_name, module, opts) do
     quote do
-      def unquote(:"get_#{name}")(id, repo_opts \\ []) do
-        assocs = repo_opts[:assocs] || []
+      def unquote(:"get_#{name}")(id, opts \\ []) do
+        assocs = opts[:assocs] || []
 
         unquote(module)
-        |> unquote(get_repo_module(opts)).get(id, repo_opts)
+        |> unquote(get_repo_module(opts)).get(id, opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
-      def unquote(:"get_#{name}_by")(clauses, repo_opts \\ []) do
-        assocs = repo_opts[:assocs] || []
+      def unquote(:"get_#{name}_by")(clauses, opts \\ []) do
+        assocs = opts[:assocs] || []
 
         unquote(module)
-        |> unquote(get_repo_module(opts)).get_by(clauses, repo_opts)
+        |> unquote(get_repo_module(opts)).get_by(clauses, opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
+      @deprecated unquote("Use get_#{name}/2 instead")
       def unquote(:"get_#{name}_with_assocs")(id, assocs, repo_opts \\ []) do
         unquote(module)
         |> unquote(get_repo_module(opts)).get(id, repo_opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
+      @deprecated unquote("Use get_#{name}_by/2 instead")
       def unquote(:"get_#{name}_by_with_assocs")(clauses, assocs, repo_opts \\ []) do
         unquote(module)
         |> unquote(get_repo_module(opts)).get_by(clauses, repo_opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
-      def unquote(:"get_#{name}!")(id, repo_opts \\ []) do
-        assocs = repo_opts[:assocs] || []
+      def unquote(:"get_#{name}!")(id, opts \\ []) do
+        assocs = opts[:assocs] || []
 
         unquote(module)
-        |> unquote(get_repo_module(opts)).get!(id, repo_opts)
+        |> unquote(get_repo_module(opts)).get!(id, opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
-      def unquote(:"get_#{name}_by!")(clauses, repo_opts \\ []) do
-        assocs = repo_opts[:assocs] || []
+      def unquote(:"get_#{name}_by!")(clauses, opts \\ []) do
+        assocs = opts[:assocs] || []
 
         unquote(module)
-        |> unquote(get_repo_module(opts)).get_by!(clauses, repo_opts)
+        |> unquote(get_repo_module(opts)).get_by!(clauses, opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
+      @deprecated unquote("Use get_#{name}!/2 instead")
       def unquote(:"get_#{name}_with_assocs!")(id, assocs, repo_opts \\ []) do
         unquote(module)
         |> unquote(get_repo_module(opts)).get!(id, repo_opts)
         |> unquote(get_repo_module(opts)).preload(assocs)
       end
 
+      @deprecated unquote("Use get_#{name}_by!/2 instead")
       def unquote(:"get_#{name}_by_with_assocs!")(clauses, assocs, repo_opts \\ []) do
         unquote(module)
         |> unquote(get_repo_module(opts)).get_by!(clauses, repo_opts)

--- a/lib/crudry_context.ex
+++ b/lib/crudry_context.ex
@@ -29,40 +29,60 @@ defmodule Crudry.Context do
 
         ## Get functions
 
-        def get_my_schema(id) do
-          Repo.get(MySchema, id)
+        def get_my_schema(id, opts \\\\ []) do
+          assocs = opts[:assoc] || []
+
+          MySchema
+          |> Repo.get(id)
+          |> Repo.preload(assocs)
         end
 
-        def get_my_schema!(id) do
-          Repo.get!(MySchema, id)
+        def get_my_schema!(id, opts \\\\ []) do
+          assocs = opts[:assoc] || []
+
+          MySchema
+          |> Repo.get!(id)
+          |> Repo.preload(assocs)
         end
 
+        @deprecated "Use get_schema/2 instead"
         def get_my_schema_with_assocs(id, assocs) do
           MySchema
           |> Repo.get(id)
           |> Repo.preload(assocs)
         end
 
+        @deprecated "Use get_schema!/2 instead"
         def get_my_schema_with_assocs!(id, assocs) do
           MySchema
           |> Repo.get!(id)
           |> Repo.preload(assocs)
         end
 
-        def get_my_schema_by(clauses) do
-          Repo.get_by(MySchema, clauses)
+        def get_my_schema_by(clauses, opts \\\\ []) do
+          assocs = opts[:assoc] || []
+
+          MySchema
+          |> Repo.get_by(clauses)
+          |> Repo.preload(assocs)
         end
 
-        def get_my_schema_by!(clauses) do
-          Repo.get_by!(MySchema, clauses)
+        def get_my_schema_by!(clauses, opts \\\\ []) do
+          assocs = opts[:assoc] || []
+
+          MySchema
+          |> Repo.get_by!(clauses)
+          |> Repo.preload(assocs)
         end
 
+        @deprecated "Use get_my_schema_by/2 instead"
         def get_my_schema_by_with_assocs(clauses, assocs) do
           MySchema
           |> Repo.get_by(clauses)
           |> Repo.preload(assocs)
         end
 
+        @deprecated "Use get_my_schema_by!/2 instead"
         def get_my_schema_by_with_assocs!(clauses, assocs) do
           MySchema
           |> Repo.get_by!(clauses)

--- a/lib/middlewares/translate_errors.ex
+++ b/lib/middlewares/translate_errors.ex
@@ -4,7 +4,7 @@ defmodule Crudry.Middlewares.TranslateErrors do
 
   ## Usage
 
-  `Cudry.Translator` is used by default to translate error messages to the default locale `en`. You can also use your own Gettext module by adding it to your Absinthe's schema `context/1` function:
+  `Crudry.Translator` is used by default to translate error messages to the default locale `en`. You can also use your own Gettext module by adding it to your Absinthe's schema `context/1` function:
 
       def context(context) do
         Map.put(context, :translator, MyAppWeb.Gettext)

--- a/test/crudry_context_test.exs
+++ b/test/crudry_context_test.exs
@@ -80,6 +80,18 @@ defmodule CrudryContextTest do
       end
     end
 
+    test "get/2", %{user1: user1} do
+      assert UserContext.get_user(user1.id, [assocs: :posts]) == Repo.preload(user1, :posts)
+    end
+
+    test "get!/2", %{user1: user1} do
+      assert UserContext.get_user!(user1.id, [assocs: :posts]) == Repo.preload(user1, :posts)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        UserContext.get_user!(-1, [:posts])
+      end
+    end
+
     test "get_by/1", %{user1: user1} do
       assert UserContext.get_user_by(username: user1.username) == user1
       assert UserContext.get_user_by(username: "inexistent") == nil
@@ -89,6 +101,18 @@ defmodule CrudryContextTest do
       assert UserContext.get_user_by!(username: user1.username) == user1
       assert_raise Ecto.NoResultsError, fn ->
         UserContext.get_user_by!(username: "inexistent")
+      end
+    end
+
+    test "get_by/2", %{user1: user1} do
+      assert UserContext.get_user_by([username: user1.username], [assocs: :posts]) == Repo.preload(user1, :posts)
+    end
+
+    test "get_by!/2", %{user1: user1} do
+      assert UserContext.get_user_by!([username: user1.username], [assocs: :posts]) == Repo.preload(user1, :posts)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        UserContext.get_user_by!([username: "inexistent"], [:posts])
       end
     end
 
@@ -155,7 +179,7 @@ defmodule CrudryContextTest do
       end
 
       assert {:ok, %{} = user} = ContextDelete.create_user(@user)
-      assert {:ok, %{} = post} = ContextDelete.create_post(%{title: @post.title, user_id: user.id})
+      assert {:ok, %{} = _post} = ContextDelete.create_post(%{title: @post.title, user_id: user.id})
       assert {:error, %Ecto.Changeset{}} = ContextDelete.delete_user(user)
     end
 

--- a/test/crudry_resolver_test.exs
+++ b/test/crudry_resolver_test.exs
@@ -86,7 +86,7 @@ defmodule CrudryResolverTest do
     end
 
     test "create/2" do
-      assert {:ok, %User{id: id, username: @username} = user} = Resolver.create_user(@userparams, @info)
+      assert {:ok, %User{id: _id, username: @username} = _user} = Resolver.create_user(@userparams, @info)
     end
 
     test "list/2", %{user: user} do


### PR DESCRIPTION
This PR intends to optimize the amount of functions generated today by Crudry discontinuing `_with_assocs` in favor of assocs options.

Related by [issue](https://github.com/jungsoft/crudry/issues/47)